### PR TITLE
fix: don't call scrollTo if not available

### DIFF
--- a/src/backends/browser.ts
+++ b/src/backends/browser.ts
@@ -27,7 +27,7 @@ const browser = ( browserPath: F<RouterPath>, routerPath?: F<RouterPath>, option
 
     if ( options.resetScroll ) {
 
-      globalThis.window?.scrollTo ( 0, 0 );
+      globalThis.window?.scrollTo?. ( 0, 0 );
 
     }
 


### PR DESCRIPTION
In SSR environment where `linkedom-global` is used `window` will be available but scrollTo function is not.