### PR TITLE
Allow passing generic to useParams

### DIFF
--- a/src/hooks/use_params.ts
+++ b/src/hooks/use_params.ts
@@ -6,7 +6,7 @@ import type {OR, RouterParams} from '~/types';
 
 /* MAIN */
 
-const useParams = <T extends RouterParams = {}>(): OR<T> => {
+const useParams = <T extends RouterParams = RouterParams>(): OR<T> => {
 
   return useState ().params as OR<T>;
 

--- a/src/hooks/use_params.ts
+++ b/src/hooks/use_params.ts
@@ -6,9 +6,9 @@ import type {OR, RouterParams} from '~/types';
 
 /* MAIN */
 
-const useParams = (): OR<RouterParams> => {
+const useParams = <T extends RouterParams = {}>(): OR<T> => {
 
-  return useState ().params;
+  return useState ().params as OR<T>;
 
 };
 


### PR DESCRIPTION
This PR allows you to pass a generic to `useParams` like this:

```ts
const params = useParams<{ userId: string }>();

params().userId // string
```

Using it like before is the same

```ts
const params = useParams();

params().userId // string | undefined
```